### PR TITLE
EDREI-32741 - Fixing update-space

### DIFF
--- a/librato.js
+++ b/librato.js
@@ -88,7 +88,7 @@ function * dumpSpace (name, maybeSink) {
 
 function * createOrUpdateSpace (maybeSource) {
   logger.verbose('createOrUpdateSpace', { from: maybeSource })
-  const space = readJson(maybeSource)
+  const space = yield readJson(maybeSource)
   logger.debug('space definition', { space })
   yield libratoApi.createOrUpdateSpace(space)
 }


### PR DESCRIPTION
librato update-space was always reporting that name is not present
because of a missing `yield` in the code